### PR TITLE
remove extra quote in mod_io.f90

### DIFF
--- a/src/mod_io.f90
+++ b/src/mod_io.f90
@@ -1701,7 +1701,7 @@ SUBROUTINE inp_outp (xbunit)
       WRITE(*,1650) 'THREE-DIMENSIONAL NODE POWER'
     end if
     
-    1650 format (2X, 'OUTPUT OPTION '  : ', A30)
+    1650 format (2X, 'OUTPUT OPTION   : ', A30)
     
     END SUBROUTINE inp_outp
 


### PR DESCRIPTION
​The previous commit (0459aa68f7dfe1e7463dab5e4c22d7f81c4acda4) added extra quote, causing a compilation error.​​