### PR TITLE
Building with Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 *.mod
 *.o
 *.out
+
+komodo

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,50 @@
+# Makefile
+
+FC = gfortran
+FFLAGS = -O4 -cpp -Wall -Wextra -std=f2018
+
+OBJ = \
+	  mod_data.o \
+	  mod_io.o \
+	  mod_xsec.o \
+	  mod_nodal.o \
+	  mod_gpu.o \
+	  mod_cmfd.o \
+	  mod_th.o \
+	  mod_control.o \
+	  mod_trans.o \
+	  komodo.o
+
+MOD = $(OBJ:o=mod)
+
+.PHONY : default all clean
+
+EXEC = ../komodo
+
+default : all
+
+all : $(EXEC)
+
+$(EXEC) : $(OBJ)
+	$(FC) $(FFLAGS) -o $@ $^
+
+%.o : %.f90
+	$(FC) $(FFLAGS) -c $<
+
+clean:
+	$(RM) $(OBJ)
+	$(RM) $(MOD)
+	$(RM) $(EXEC)
+
+# dependencies list
+komodo.o : mod_data.o mod_io.o mod_control.o mod_trans.o
+mod_cmfd.o : mod_data.o mod_gpu.o mod_io.o mod_nodal.o
+mod_control.o : mod_data.o mod_io.o mod_xsec.o mod_cmfd.o mod_th.o
+mod_data.o : 
+mod_gpu.o : mod_data.o
+mod_io.o : mod_data.o
+mod_nodal.o : mod_data.o mod_io.o
+mod_th.o : mod_data.o mod_cmfd.o mod_io.o mod_xsec.o
+mod_trans.o : mod_data.o mod_io.o mod_xsec.o mod_cmfd.o mod_th.o mod_control.o mod_nodal.o
+mod_xsec.o : mod_data.o mod_io.o
+


### PR DESCRIPTION
Adding a Makefile.

To use the Makefile, from within the `src` directory, simply run `make`. This now also supports parallel builds with `make -j` to build with more than one processor at the same time.

This was inspired by b112e01ce47bdd1ee45f62c0205c4ae4c1df250d in the original KOMODO repository. By using a Makefile, it is no longer necessary to maintain a specific compilation order as long as the dependency list in the Makefile is up-to-date.

I have also turned on compiler warnings. I think that this is best practice, but understand that it may be a bit annoying. I can turn them back off if that is preferred.